### PR TITLE
Add basic Chrome extension skeleton

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,3 @@
+chrome.runtime.onInstalled.addListener(() => {
+  console.log('DevTool React Extension installed');
+});

--- a/extension/content/content.js
+++ b/extension/content/content.js
@@ -1,0 +1,1 @@
+console.log('Content script loaded');

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,19 @@
+{
+  "manifest_version": 3,
+  "name": "DevTool React Extension",
+  "version": "1.0",
+  "description": "A basic Chrome extension setup.",
+  "action": {
+    "default_popup": "popup/popup.html"
+  },
+  "background": {
+    "service_worker": "background.js"
+  },
+  "permissions": ["storage"],
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content/content.js"]
+    }
+  ]
+}

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>DevTool React Extension</title>
+  </head>
+  <body>
+    <div id="message">Loading...</div>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -1,0 +1,6 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const element = document.getElementById('message');
+  if (element) {
+    element.textContent = 'Extension popup loaded';
+  }
+});


### PR DESCRIPTION
## Summary
- Add manifest.json describing extension configuration
- Implement background script, popup UI, and content script

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a15d224dc48325835023be0e5a0c08