### PR TITLE
feat: execute script on active tab

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -9,7 +9,7 @@
   "background": {
     "service_worker": "background.js"
   },
-  "permissions": ["storage"],
+  "permissions": ["storage", "activeTab", "scripting"],
   "content_scripts": [
     {
       "matches": ["<all_urls>"],

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -5,7 +5,8 @@
     <title>DevTool React Extension</title>
   </head>
   <body>
-    <div id="message">Loading...</div>
-    <script src="popup.js"></script>
+      <div id="message">Loading...</div>
+      <button id="run-script">Get URL</button>
+      <script src="popup.js"></script>
   </body>
 </html>

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -3,4 +3,25 @@ document.addEventListener('DOMContentLoaded', () => {
   if (element) {
     element.textContent = 'Extension popup loaded';
   }
+
+  const button = document.getElementById('run-script');
+  if (button) {
+    button.addEventListener('click', async () => {
+      try {
+        const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+        const [{ result }] = await chrome.scripting.executeScript({
+          target: { tabId: tab.id },
+          func: () => window.location.href,
+        });
+        if (element) {
+          element.textContent = result;
+        }
+      } catch (error) {
+        if (element) {
+          element.textContent = `Error: ${error.message}`;
+        }
+      }
+    });
+  }
 });
+


### PR DESCRIPTION
## Summary
- allow popup to query active tab and display its URL
- require activeTab and scripting permissions
- add button to trigger script execution

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a15f7859a08325b07c83ee7efa7bbe