### PR TITLE
feat: add context menu for tab URL

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,3 +1,25 @@
 chrome.runtime.onInstalled.addListener(() => {
   console.log('DevTool React Extension installed');
+
+  // Create the top-level context menu
+  chrome.contextMenus.create({
+    id: 'devtoolRoot',
+    title: 'DevTool Menu',
+    contexts: ['all']
+  });
+
+  // Create the sub-menu item that prints the current tab URL
+  chrome.contextMenus.create({
+    id: 'printTabUrl',
+    parentId: 'devtoolRoot',
+    title: 'Print Current Tab URL',
+    contexts: ['all']
+  });
+});
+
+// Handle context menu clicks
+chrome.contextMenus.onClicked.addListener((info, tab) => {
+  if (info.menuItemId === 'printTabUrl' && tab) {
+    console.log(tab.url);
+  }
 });

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -9,7 +9,7 @@
   "background": {
     "service_worker": "background.js"
   },
-  "permissions": ["storage", "activeTab", "scripting"],
+  "permissions": ["storage", "activeTab", "scripting", "contextMenus", "tabs"],
   "content_scripts": [
     {
       "matches": ["<all_urls>"],


### PR DESCRIPTION
## Summary
- log current tab URL from new context menu
- register context menu in manifest

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1616c172083259777af00391e3e2e